### PR TITLE
Updating vault binary URL. Bintray returns 404.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,4 +47,4 @@ default[:vault][:server][:listeners] = {
 # Derived values, not meant to be manually set
 ###############################################################################
 default[:vault][:zip_file] = "vault_#{node[:vault][:version]}_linux_amd64.zip"
-default[:vault][:download_url] = "https://dl.bintray.com/mitchellh/vault/#{node[:vault][:zip_file]}"
+default[:vault][:download_url] = "https://releases.hashicorp.com/vault/#{node[:vault][:zip_file]}"


### PR DESCRIPTION
Binary download URLs all return as 404 at bintray. The download links on vaultproject.io point to releases.hashicorp.com, this patch is to update the download location.
